### PR TITLE
Bump up gradle version to 2.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN dpkg --add-architecture i386 \
 # gradle
 # ================================================================
 
-ENV GRADLE_VERSION 2.13
+ENV GRADLE_VERSION 2.14
 RUN curl -L -O "http://services.gradle.org/distributions/gradle-$GRADLE_VERSION-all.zip" \
     && unzip -q -o "gradle-$GRADLE_VERSION-all.zip" \
     && mv "gradle-$GRADLE_VERSION" "/usr/local/gradle-$GRADLE_VERSION" \


### PR DESCRIPTION
I bumped up gradle current version 2.14.
# Problems

If project uses android-maven-gradle-plugin 1.4, build fails because this plugin is compatible with gradle 2.14. Please refer to the following link.

https://github.com/dcendents/android-maven-gradle-plugin/issues/33
